### PR TITLE
remove last occurrence of VS1053

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Schematic<br>
 
 #### Some features:
 
-- The audioprocess works in its own task and is decoupled. If a VS1053 is used, it must have its own SPI bus (VS1053 uses HSPI - TFT uses VSPI). This prevents dropouts when drawing on the display or when the website is loading.
+- The audioprocess works in its own task and is decoupled. This prevents dropouts when drawing on the display or when the website is loading.
 - The SD card is wired as SD_MMC to improve stability and increase speed. This means that the GPIOs cannot be chosen freely. The [SD card adapter](docs/SD_Card_Adapter_for_SD_MMC_.jpg) must not have any resistors in series. For best display update speed, use 40MHz frequency for SD card if possible (SDMMC_FREQUENCY 40000000 in common.h).
 - Audio can be decoded using software. Possible formats are mp3, aac, mp4, opus, vorbis and flac.
 - External DACs (e.g. UDA13348, MAX98357A, PCM5102A) are connected via I2S, ES8388 and AC101 also require an I2C connection


### PR DESCRIPTION
Since the VS1053 is not supported anymore and the other occurrence of the VS1053 was removed already removed with e2a90dd it makes sense to remove the last mention also.  
  
Or should it be mentioned explicitly that there is no more VS1053 support after [tag V.2.15.0](https://github.com/schreibfaul1/ESP32-MiniWebRadio/releases/tag/V.2.15.0) or rather 5db3e71?