### PR TITLE
make display hardcopies for all displays

### DIFF
--- a/lib/tftLib/tft_spi.cpp
+++ b/lib/tftLib/tft_spi.cpp
@@ -848,57 +848,57 @@ void TFT_SPI::startBitmap(uint16_t x, uint16_t y, uint16_t w, uint16_t h) {
         spi_TFT.write(ili9341_rotations[_rotation].bmpctl);
     }
     setAddrWindow(x, m_v_res - y - h, w, h);
-    if(_TFTcontroller == HX8347D) { // HX8347D
-        if(_rotation == 0) {
-            writeCommand(0x16);
-            spi_TFT.write(0x88);
-        } // 0
-        if(_rotation == 1) {
-            writeCommand(0x16);
-            spi_TFT.write(0x38);
-        } // 90
-        if(_rotation == 2) {
-            writeCommand(0x16);
-            spi_TFT.write(0x48);
-        } // 180
-        if(_rotation == 3) {
-            writeCommand(0x16);
-            spi_TFT.write(0xE8);
-        } // 270
-        writeCommand(0x22);
-    }
-    if(_TFTcontroller == ILI9486a || _TFTcontroller == ILI9486b) {
-        writeCommand(ILI9486_MADCTL);
-        if(_rotation == 0) { spi_TFT.write16(ILI9486_MADCTL_MX | ILI9486_MADCTL_MY | ILI9486_MADCTL_ML | ILI9486_MADCTL_BGR); }
-        if(_rotation == 1) { spi_TFT.write16(ILI9486_MADCTL_MH | ILI9486_MADCTL_MV | ILI9486_MADCTL_MX | ILI9486_MADCTL_BGR); }
-        if(_rotation == 2) { spi_TFT.write16(ILI9486_MADCTL_MH | ILI9486_MADCTL_BGR); }
-        if(_rotation == 3) { spi_TFT.write16(ILI9486_MADCTL_MV | ILI9486_MADCTL_MY | ILI9486_MADCTL_BGR); }
-        writeCommand(ILI9486_RAMWR);
-    }
-    if(_TFTcontroller == ILI9488) {
-        writeCommand(ILI9488_MADCTL);
-        if(_rotation == 0) { spi_TFT.write(ILI9488_MADCTL_MX | ILI9488_MADCTL_MY | ILI9488_MADCTL_ML | ILI9488_MADCTL_BGR); }
-        if(_rotation == 1) { spi_TFT.write(ILI9488_MADCTL_MH | ILI9488_MADCTL_MV | ILI9488_MADCTL_MX | ILI9488_MADCTL_BGR); }
-        if(_rotation == 2) { spi_TFT.write(ILI9488_MADCTL_MH | ILI9488_MADCTL_BGR); }
-        if(_rotation == 3) { spi_TFT.write(ILI9488_MADCTL_MV | ILI9488_MADCTL_MY | ILI9488_MADCTL_BGR); }
-        writeCommand(ILI9488_RAMWR);
-    }
-    if(_TFTcontroller == ST7796) {
-        writeCommand(ST7796_MADCTL);
-        if(_rotation == 0) { spi_TFT.write(ST7796_MADCTL_MX | ST7796_MADCTL_MY | ST7796_MADCTL_ML | ST7796_MADCTL_BGR); }
-        if(_rotation == 1) { spi_TFT.write(ST7796_MADCTL_MH | ST7796_MADCTL_MV | ST7796_MADCTL_MX | ST7796_MADCTL_BGR); }
-        if(_rotation == 2) { spi_TFT.write(ST7796_MADCTL_MH | ST7796_MADCTL_BGR); }
-        if(_rotation == 3) { spi_TFT.write(ST7796_MADCTL_MV | ST7796_MADCTL_MY | ST7796_MADCTL_BGR); }
-        writeCommand(ST7796_RAMWR);
-    }
-    if(_TFTcontroller == ST7796RPI) {
-        writeCommand(ST7796_MADCTL);
-        if(_rotation == 0) { spi_TFT.write16(ST7796_MADCTL_MX | ST7796_MADCTL_MY | ST7796_MADCTL_ML | ST7796_MADCTL_BGR); }
-        if(_rotation == 1) { spi_TFT.write16(ST7796_MADCTL_MH | ST7796_MADCTL_MV | ST7796_MADCTL_MX | ST7796_MADCTL_BGR); }
-        if(_rotation == 2) { spi_TFT.write16(ST7796_MADCTL_MH | ST7796_MADCTL_BGR); }
-        if(_rotation == 3) { spi_TFT.write16(ST7796_MADCTL_MV | ST7796_MADCTL_MY | ST7796_MADCTL_BGR); }
-        writeCommand(ST7796_RAMWR);
-    }
+    // if(_TFTcontroller == HX8347D) { // HX8347D
+    //     if(_rotation == 0) {
+    //         writeCommand(0x16);
+    //         spi_TFT.write(0x88);
+    //     } // 0
+    //     if(_rotation == 1) {
+    //         writeCommand(0x16);
+    //         spi_TFT.write(0x38);
+    //     } // 90
+    //     if(_rotation == 2) {
+    //         writeCommand(0x16);
+    //         spi_TFT.write(0x48);
+    //     } // 180
+    //     if(_rotation == 3) {
+    //         writeCommand(0x16);
+    //         spi_TFT.write(0xE8);
+    //     } // 270
+    //     writeCommand(0x22);
+    // }
+    // if(_TFTcontroller == ILI9486a || _TFTcontroller == ILI9486b) {
+    //     writeCommand(ILI9486_MADCTL);
+    //     if(_rotation == 0) { spi_TFT.write16(ILI9486_MADCTL_MX | ILI9486_MADCTL_MY | ILI9486_MADCTL_ML | ILI9486_MADCTL_BGR); }
+    //     if(_rotation == 1) { spi_TFT.write16(ILI9486_MADCTL_MH | ILI9486_MADCTL_MV | ILI9486_MADCTL_MX | ILI9486_MADCTL_BGR); }
+    //     if(_rotation == 2) { spi_TFT.write16(ILI9486_MADCTL_MH | ILI9486_MADCTL_BGR); }
+    //     if(_rotation == 3) { spi_TFT.write16(ILI9486_MADCTL_MV | ILI9486_MADCTL_MY | ILI9486_MADCTL_BGR); }
+    //     writeCommand(ILI9486_RAMWR);
+    // }
+    // if(_TFTcontroller == ILI9488) {
+    //     writeCommand(ILI9488_MADCTL);
+    //     if(_rotation == 0) { spi_TFT.write(ILI9488_MADCTL_MX | ILI9488_MADCTL_MY | ILI9488_MADCTL_ML | ILI9488_MADCTL_BGR); }
+    //     if(_rotation == 1) { spi_TFT.write(ILI9488_MADCTL_MH | ILI9488_MADCTL_MV | ILI9488_MADCTL_MX | ILI9488_MADCTL_BGR); }
+    //     if(_rotation == 2) { spi_TFT.write(ILI9488_MADCTL_MH | ILI9488_MADCTL_BGR); }
+    //     if(_rotation == 3) { spi_TFT.write(ILI9488_MADCTL_MV | ILI9488_MADCTL_MY | ILI9488_MADCTL_BGR); }
+    //     writeCommand(ILI9488_RAMWR);
+    // }
+    // if(_TFTcontroller == ST7796) {
+    //     writeCommand(ST7796_MADCTL);
+    //     if(_rotation == 0) { spi_TFT.write(ST7796_MADCTL_MX | ST7796_MADCTL_MY | ST7796_MADCTL_ML | ST7796_MADCTL_BGR); }
+    //     if(_rotation == 1) { spi_TFT.write(ST7796_MADCTL_MH | ST7796_MADCTL_MV | ST7796_MADCTL_MX | ST7796_MADCTL_BGR); }
+    //     if(_rotation == 2) { spi_TFT.write(ST7796_MADCTL_MH | ST7796_MADCTL_BGR); }
+    //     if(_rotation == 3) { spi_TFT.write(ST7796_MADCTL_MV | ST7796_MADCTL_MY | ST7796_MADCTL_BGR); }
+    //     writeCommand(ST7796_RAMWR);
+    // }
+    // if(_TFTcontroller == ST7796RPI) {
+    //     writeCommand(ST7796_MADCTL);
+    //     if(_rotation == 0) { spi_TFT.write16(ST7796_MADCTL_MX | ST7796_MADCTL_MY | ST7796_MADCTL_ML | ST7796_MADCTL_BGR); }
+    //     if(_rotation == 1) { spi_TFT.write16(ST7796_MADCTL_MH | ST7796_MADCTL_MV | ST7796_MADCTL_MX | ST7796_MADCTL_BGR); }
+    //     if(_rotation == 2) { spi_TFT.write16(ST7796_MADCTL_MH | ST7796_MADCTL_BGR); }
+    //     if(_rotation == 3) { spi_TFT.write16(ST7796_MADCTL_MV | ST7796_MADCTL_MY | ST7796_MADCTL_BGR); }
+    //     writeCommand(ST7796_RAMWR);
+    // }
     endWrite();
 }
 //——————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————
@@ -1125,12 +1125,7 @@ void TFT_SPI::drawLine(int16_t x0, int16_t y0, int16_t x1, int16_t y1, uint16_t 
         }
     }
     startWrite();
-    if(_TFTcontroller == ILI9341) { // ILI9341
-        writeCommand(ILI9341_MADCTL);
-        spi_TFT.write(ili9341_rotations[_rotation].bmpctl);
-    }
-    setAddrWindow(x, m_v_res - y - h, w, h);
-
+    setAddrWindow(x, y, w, h);
     for(int16_t j = y; j < h; j++) {
         writePixels(m_framebuffer[0] + j * m_h_res + x, w);
     }
@@ -1149,148 +1144,311 @@ void TFT_SPI::fillRect(int16_t x, int16_t y, int16_t w, int16_t h, uint16_t colo
             m_framebuffer[0][j * m_h_res + i] = color;
         }
     }
-    startBitmap(x0, y0, x1 - x0, y1 - y0);
     startWrite();
+    setAddrWindow(x, y, w, h);
     for(int16_t j = y0; j < y1; j++) {
         writeColor(color, x1 - x0);
     }
     endWrite();
-    endBitmap();
 }
 //——————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————
 void TFT_SPI::fillScreen(uint16_t color) {
     fill(m_framebuffer[0], m_framebuffer[0] + (m_h_res * m_v_res), color);
-    startBitmap(0, 0, m_h_res, m_v_res);
+
     startWrite();
+    setAddrWindow(0, 0, m_h_res, m_v_res);
     writeColor(color, m_h_res * m_v_res);
     endWrite();
-    endBitmap();
 }
 //——————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————
 void TFT_SPI::drawTriangle(int16_t x0, int16_t y0, int16_t x1, int16_t y1, int16_t x2, int16_t y2, uint16_t color) {
-    drawLine(x0, y0, x1, y1, color);
-    drawLine(x1, y1, x2, y2, color);
-    drawLine(x2, y2, x0, y0, color);
+    if(x0 < 0 || x0 >= m_h_res || x1 < 0 || x1 >= m_h_res || x2 < 0 || x2 >= m_h_res || y0 < 0 || y0 >= m_v_res || y1 < 0 || y1 >= m_v_res || y2 < 0 || y2 >= m_v_res) return;
+
+    auto drawLine = [](int16_t x0, int16_t y0, int16_t x1, int16_t y1, uint16_t color, uint16_t* m_framebuffer[0], uint16_t m_h_res) {
+        // Bresenham-Algorithmus für Linien
+        int16_t dx = abs(x1 - x0), sx = x0 < x1 ? 1 : -1;
+        int16_t dy = -abs(y1 - y0), sy = y0 < y1 ? 1 : -1;
+        int16_t err = dx + dy, e2; // Fehlerwert
+
+        while (true) {
+            m_framebuffer[0][y0 * m_h_res + x0] = color; // Pixel setzen
+            if (x0 == x1 && y0 == y1) break;
+            e2 = 2 * err;
+            if (e2 >= dy) { err += dy; x0 += sx; }
+            if (e2 <= dx) { err += dx; y0 += sy; }
+        }
+    };
+
+
+    // Zeichne die drei Linien des Dreiecks
+    drawLine(x0, y0, x1, y1, color, &m_framebuffer[0], m_h_res); // Linie von Punkt 0 nach Punkt 1
+    drawLine(x1, y1, x2, y2, color, &m_framebuffer[0], m_h_res); // Linie von Punkt 1 nach Punkt 2
+    drawLine(x2, y2, x0, y0, color, &m_framebuffer[0], m_h_res); // Linie von Punkt 2 nach Punkt 0
+
+    // Aktualisierung des gezeichneten Bereichs
+    int16_t x = std::min({x0, x1, x2});
+    int16_t y = std::min({y0, y1, y2});
+    int16_t w = std::max({x0, x1, x2}) - x + 1;
+    int16_t h = std::max({y0, y1, y2}) - y + 1;
+
+    startWrite();
+    setAddrWindow(x, y, w, h);
+    for(int16_t j = y; j < y + h; j++) {
+        writePixels(m_framebuffer[0] + j * m_h_res + x, w);
+    }
+    endWrite();
 }
 //——————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————
 void TFT_SPI::fillTriangle(int16_t x0, int16_t y0, int16_t x1, int16_t y1, int16_t x2, int16_t y2, uint16_t color) {
-    int16_t a, b, y, last;
-    // Sort coordinates by Y order (y2 >= y1 >= y0)
-    if(y0 > y1) {
-        _swap_int16_t(y0, y1);
-        _swap_int16_t(x0, x1);
-    }
-    if(y1 > y2) {
-        _swap_int16_t(y2, y1);
-        _swap_int16_t(x2, x1);
-    }
-    if(y0 > y1) {
-        _swap_int16_t(y0, y1);
-        _swap_int16_t(x0, x1);
+    if(x0 < 0 || x0 >= m_h_res || x1 < 0 || x1 >= m_h_res || x2 < 0 || x2 >= m_h_res || y0 < 0 || y0 >= m_v_res || y1 < 0 || y1 >= m_v_res || y2 < 0 || y2 >= m_v_res) return;
+
+ // Helferfunktion zum Zeichnen einer horizontalen Linie
+    auto drawHorizontalLine = [&](int16_t x_start, int16_t x_end, int16_t y) {
+        if (y >= 0 && y < m_v_res) { // Clipping in y-Richtung
+            if (x_start > x_end) std::swap(x_start, x_end);
+            x_start = std::max((int16_t)0, x_start); // Clipping in x-Richtung
+            x_end = std::min((int16_t)(m_h_res - 1), x_end);
+            for (int16_t x = x_start; x <= x_end; ++x) {
+                m_framebuffer[0][y * m_h_res + x] = color;
+            }
+        }
+    };
+
+    // Punkte nach ihrer y-Koordinate sortieren
+    if (y0 > y1) { std::swap(y0, y1); std::swap(x0, x1); }
+    if (y1 > y2) { std::swap(y1, y2); std::swap(x1, x2); }
+    if (y0 > y1) { std::swap(y0, y1); std::swap(x0, x1); }
+
+    // Variablen zur Begrenzung des aktualisierten Bereichs
+    int16_t x_min = std::min({x0, x1, x2});
+    int16_t x_max = std::max({x0, x1, x2});
+    int16_t y_min = std::min({y0, y1, y2});
+    int16_t y_max = std::max({y0, y1, y2});
+
+    // Clipping auf Framebuffer-Grenzen
+    int16_t x = std::max((int16_t)0, x_min);
+    int16_t w = std::min((int16_t)(m_h_res - 1), x_max) - x + 1;
+    int16_t y = std::max((int16_t)0, y_min);
+    int16_t h = std::min((int16_t)(m_v_res - 1), y_max) - y + 1;
+
+
+    // Dreieck in zwei Teile zerlegen (oben und unten)
+    if (y1 == y2) { // Sonderfall: flaches unteres Dreieck
+        for (int16_t i = y0; i <= y1; ++i) {
+            int16_t x_start = x0 + (x1 - x0) * (i - y0) / (y1 - y0);
+            int16_t x_end = x0 + (x2 - x0) * (i - y0) / (y2 - y0);
+            drawHorizontalLine(x_start, x_end, i);
+        }
+    } else if (y0 == y1) { // Sonderfall: flaches oberes Dreieck
+        for (int16_t i = y0; i <= y2; ++i) {
+            int16_t x_start = x0 + (x2 - x0) * (i - y0) / (y2 - y0);
+            int16_t x_end = x1 + (x2 - x1) * (i - y1) / (y2 - y1);
+            drawHorizontalLine(x_start, x_end, i);
+        }
+    } else { // Allgemeiner Fall: Dreieck wird in zwei Teile aufgeteilt
+        for (int16_t i = y0; i <= y1; ++i) { // Unterer Teil
+            int16_t x_start = x0 + (x1 - x0) * (i - y0) / (y1 - y0);
+            int16_t x_end = x0 + (x2 - x0) * (i - y0) / (y2 - y0);
+            drawHorizontalLine(x_start, x_end, i);
+        }
+        for (int16_t i = y1; i <= y2; ++i) { // Oberer Teil
+            int16_t x_start = x1 + (x2 - x1) * (i - y1) / (y2 - y1);
+            int16_t x_end = x0 + (x2 - x0) * (i - y0) / (y2 - y0);
+            drawHorizontalLine(x_start, x_end, i);
+        }
     }
     startWrite();
-    if(y0 == y2) { // Handle awkward all-on-same-line case as its own thing
-        a = b = x0;
-        if(x1 < a) a = x1;
-        else if(x1 > b) b = x1;
-        if(x2 < a) a = x2;
-        else if(x2 > b) b = x2;
-        writeFastHLine(a, y0, b - a + 1, color);
-        endWrite();
-        return;
-    }
-    int16_t dx01 = x1 - x0, dy01 = y1 - y0, dx02 = x2 - x0, dy02 = y2 - y0, dx12 = x2 - x1, dy12 = y2 - y1;
-    int32_t sa = 0, sb = 0;
-
-    // For upper part of triangle, find scanline crossings for segments 0-1 and 0-2.  If y1=y2 (flat-bottomed triangle), the scanline y1
-    // is included here (and second loop will be skipped, avoiding a /0 error there), otherwise scanline y1 is skipped here and handled
-    // in the second loop...which also avoids a /0 error here if y0=y1(flat-topped triangle).
-    if(y1 == y2) last = y1; // Include y1 scanline
-    else last = y1 - 1;     // Skip it
-
-    for(y = y0; y <= last; y++) {
-        a = x0 + sa / dy01;
-        b = x0 + sb / dy02;
-        sa += dx01;
-        sb += dx02;
-        /* longhand:
-         a = x0 + (x1 - x0) * (y - y0) / (y1 - y0);
-         b = x0 + (x2 - x0) * (y - y0) / (y2 - y0);
-         */
-        if(a > b) _swap_int16_t(a, b);
-        writeFastHLine(a, y, b - a + 1, color);
-    }
-
-    // For lower part of triangle, find scanline crossings for segments
-    // 0-2 and 1-2.  This loop is skipped if y1=y2.
-    sa = (int32_t)dx12 * (y - y1);
-    sb = (int32_t)dx02 * (y - y0);
-    for(; y <= y2; y++) {
-        a = x1 + sa / dy12;
-        b = x0 + sb / dy02;
-        sa += dx12;
-        sb += dx02;
-        /* longhand:
-         a = x1 + (x2 - x1) * (y - y1) / (y2 - y1);
-         b = x0 + (x2 - x0) * (y - y0) / (y2 - y0);
-         */
-        if(a > b) _swap_int16_t(a, b);
-        writeFastHLine(a, y, b - a + 1, color);
+    setAddrWindow(x, y, w, h);
+    for(int16_t j = y; j < y + h; j++) {
+        writePixels(m_framebuffer[0] + j * m_h_res + x, w);
     }
     endWrite();
 }
 //——————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————
 void TFT_SPI::drawRect(int16_t Xpos, int16_t Ypos, uint16_t Width, uint16_t Height, uint16_t Color) {
-    if(Width < 1 || Height < 1) return;
+    if(Xpos < 0 || Xpos >= m_h_res || Ypos < 0 || Ypos >= m_v_res) return;
+    if(Width == 0 || Height == 0) return;
+    if(Width > m_h_res - Xpos) Width = m_h_res - Xpos;
+    if(Height > m_v_res - Ypos) Height = m_v_res - Ypos;
+
+    auto drawLine = [](int16_t x0, int16_t y0, int16_t x1, int16_t y1, uint16_t color, uint16_t* fb, uint16_t m_h_res) {
+        // Bresenham-Algorithmus für Linien
+        int16_t dx = abs(x1 - x0), sx = x0 < x1 ? 1 : -1;
+        int16_t dy = -abs(y1 - y0), sy = y0 < y1 ? 1 : -1;
+        int16_t err = dx + dy, e2; // Fehlerwert
+
+        while (true) {
+            fb[y0 * m_h_res + x0] = color; // Pixel setzen
+            if (x0 == x1 && y0 == y1) break;
+            e2 = 2 * err;
+            if (e2 >= dy) { err += dy; x0 += sx; }
+            if (e2 <= dx) { err += dx; y0 += sy; }
+        }
+    };
+
+    // Zeichne die vier Linien des Rechtecks
+    drawLine(Xpos, Ypos, Xpos + Width, Ypos, Color, m_framebuffer[0], m_h_res); // Oben
+    drawLine(Xpos + Width - 1, Ypos, Xpos + Width - 1, Ypos + Height - 1, Color, m_framebuffer[0], m_h_res); // Rechts
+    drawLine(Xpos, Ypos + Height - 1, Xpos + Width - 1, Ypos + Height - 1, Color, m_framebuffer[0], m_h_res); // Unten
+    drawLine(Xpos, Ypos + Height, Xpos, Ypos, Color, m_framebuffer[0], m_h_res); // Links
+
+    // Aktualisierung des gezeichneten Bereichs
+    int16_t x = std::min((int)Xpos, Xpos + Width);
+    int16_t y = std::min((int)Ypos, Ypos + Height);
+    int16_t w = std::max((int)Xpos, Xpos + Width) - x;
+    int16_t h = std::max((int)Ypos, Ypos + Height) - y;
+
     startWrite();
-    writeFastHLine(Xpos, Ypos, Width, Color);
-    writeFastHLine(Xpos, Ypos + Height - 1, Width, Color);
-    writeFastVLine(Xpos, Ypos, Height, Color);
-    writeFastVLine(Xpos + Width - 1, Ypos, Height, Color);
+    setAddrWindow(x, y, w, h);
+    for(int16_t j = y; j < y + h; j++) {
+        writePixels(m_framebuffer[0] + j * m_h_res + x, w);
+    }
     endWrite();
 }
 //——————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————
 void TFT_SPI::drawRoundRect(int16_t x, int16_t y, int16_t w, int16_t h, int16_t r, uint16_t color) {
-    // smarter version
+    // Helferfunktion: Kreislinie für die Ecken berechnen
+    auto drawCircleQuadrant = [&](int16_t cx, int16_t cy, int16_t r, uint8_t quadrant) {
+        int16_t f = 1 - r;
+        int16_t ddF_x = 1;
+        int16_t ddF_y = -2 * r;
+        int16_t x = 0;
+        int16_t y = r;
+
+        while (x <= y) {
+            if (quadrant & 0x1) m_framebuffer[0][(cy - y) * m_h_res + (cx + x)] = color; // oben rechts
+            if (quadrant & 0x2) m_framebuffer[0][(cy + y) * m_h_res + (cx + x)] = color; // unten rechts
+            if (quadrant & 0x4) m_framebuffer[0][(cy + y) * m_h_res + (cx - x)] = color; // unten links
+            if (quadrant & 0x8) m_framebuffer[0][(cy - y) * m_h_res + (cx - x)] = color; // oben links
+
+            if (quadrant & 0x10) m_framebuffer[0][(cy - x) * m_h_res + (cx + y)] = color; // oben rechts (90° gedreht)
+            if (quadrant & 0x20) m_framebuffer[0][(cy + x) * m_h_res + (cx + y)] = color; // unten rechts (90° gedreht)
+            if (quadrant & 0x40) m_framebuffer[0][(cy + x) * m_h_res + (cx - y)] = color; // unten links (90° gedreht)
+            if (quadrant & 0x80) m_framebuffer[0][(cy - x) * m_h_res + (cx - y)] = color; // oben links (90° gedreht)
+
+            if (f >= 0) {
+                y--;
+                ddF_y += 2;
+                f += ddF_y;
+            }
+            x++;
+            ddF_x += 2;
+            f += ddF_x;
+        }
+    };
+
+    // Rechteckseiten zeichnen (ohne die abgerundeten Ecken)
+    for (int16_t i = x + r; i < x + w - r; i++) { // Obere und untere horizontale Linien
+        m_framebuffer[0][y * m_h_res + i] = color; // Oben
+        m_framebuffer[0][(y + h - 1) * m_h_res + i] = color; // Unten
+    }
+    for (int16_t i = y + r; i < y + h - r; i++) { // Linke und rechte vertikale Linien
+        m_framebuffer[0][i * m_h_res + x] = color; // Links
+        m_framebuffer[0][i * m_h_res + (x + w - 1)] = color; // Rechts
+    }
+
+    // Abgerundete Ecken zeichnen
+    drawCircleQuadrant(x + w - r - 1, y + r, r, 0x1 | 0x10); // Oben rechts
+    drawCircleQuadrant(x + w - r - 1, y + h - r - 1, r, 0x2 | 0x20); // Unten rechts
+    drawCircleQuadrant(x + r, y + h - r - 1, r, 0x4 | 0x40); // Unten links
+    drawCircleQuadrant(x + r, y + r, r, 0x8 | 0x80); // Oben links
+
+    // Aktualisierung des gezeichneten Bereichs
     startWrite();
-    writeFastHLine(x + r, y, w - 2 * r, color);         // Top
-    writeFastHLine(x + r, y + h - 1, w - 2 * r, color); // Bottom
-    writeFastVLine(x, y + r, h - 2 * r, color);         // Left
-    writeFastVLine(x + w - 1, y + r, h - 2 * r, color); // Right
-    // draw four corners
-    drawCircleHelper(x + r, y + r, r, 1, color);
-    drawCircleHelper(x + w - r - 1, y + r, r, 2, color);
-    drawCircleHelper(x + w - r - 1, y + h - r - 1, r, 4, color);
-    drawCircleHelper(x + r, y + h - r - 1, r, 8, color);
+    setAddrWindow(x, y, w, h);
+    for(int16_t j = y; j < y + h; j++) {
+        writePixels(m_framebuffer[0] + j * m_h_res + x, w);
+    }
     endWrite();
 }
 //——————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————
 void TFT_SPI::fillRoundRect(int16_t x, int16_t y, int16_t w, int16_t h, int16_t r, uint16_t color) {
-    // smarter version
-    startWrite();
-    writeFillRect(x + r, y, w - 2 * r, h, color);
+    // Helferfunktion: Kreisfüllung für die Ecken berechnen
+    auto fillCircleQuadrant = [&](int16_t cx, int16_t cy, int16_t r, uint8_t quadrant) {
+        int16_t f = 1 - r;
+        int16_t ddF_x = 1;
+        int16_t ddF_y = -2 * r;
+        int16_t x = 0;
+        int16_t y = r;
 
-    // draw four corners
-    fillCircleHelper(x + w - r - 1, y + r, r, 1, h - 2 * r - 1, color);
-    fillCircleHelper(x + r, y + r, r, 2, h - 2 * r - 1, color);
+        while (x <= y) {
+            for (int16_t i = 0; i <= x; i++) {
+                if (quadrant & 0x1) m_framebuffer[0][(cy - y) * m_h_res + (cx + i)] = color; // oben rechts
+                if (quadrant & 0x2) m_framebuffer[0][(cy + y) * m_h_res + (cx + i)] = color; // unten rechts
+                if (quadrant & 0x4) m_framebuffer[0][(cy + y) * m_h_res + (cx - i)] = color; // unten links
+                if (quadrant & 0x8) m_framebuffer[0][(cy - y) * m_h_res + (cx - i)] = color; // oben links
+            }
+            for (int16_t i = 0; i <= y; i++) {
+                if (quadrant & 0x10) m_framebuffer[0][(cy - x) * m_h_res + (cx + i)] = color; // oben rechts (gedreht)
+                if (quadrant & 0x20) m_framebuffer[0][(cy + x) * m_h_res + (cx + i)] = color; // unten rechts (gedreht)
+                if (quadrant & 0x40) m_framebuffer[0][(cy + x) * m_h_res + (cx - i)] = color; // unten links (gedreht)
+                if (quadrant & 0x80) m_framebuffer[0][(cy - x) * m_h_res + (cx - i)] = color; // oben links (gedreht)
+            }
+
+            if (f >= 0) {
+                y--;
+                ddF_y += 2;
+                f += ddF_y;
+            }
+            x++;
+            ddF_x += 2;
+            f += ddF_x;
+        }
+    };
+
+    // Horizontale Bereiche zwischen den oberen und unteren Viertelkreisen füllen
+    for (int16_t i = y; i < y + r; i++) { // Bereich oberhalb der Viertelkreise
+        for (int16_t j = x + r; j < x + w - r; j++) {
+            m_framebuffer[0][i * m_h_res + j] = color;
+        }
+    }
+    for (int16_t i = y + h - r; i < y + h; i++) { // Bereich unterhalb der Viertelkreise
+        for (int16_t j = x + r; j < x + w - r; j++) {
+            m_framebuffer[0][i * m_h_res + j] = color;
+        }
+    }
+
+    // Vertikaler Bereich zwischen den Viertelkreisen füllen
+    for (int16_t i = y + r; i < y + h - r; i++) { // Vertikaler Bereich
+        for (int16_t j = x; j < x + w; j++) { // Horizontaler Bereich
+            m_framebuffer[0][i * m_h_res + j] = color;
+        }
+    }
+
+    // Viertelkreise in den Ecken füllen
+    fillCircleQuadrant(x + w - r - 1, y + r, r, 0x1 | 0x10); // Oben rechts
+    fillCircleQuadrant(x + w - r - 1, y + h - r - 1, r, 0x2 | 0x20); // Unten rechts
+    fillCircleQuadrant(x + r, y + h - r - 1, r, 0x4 | 0x40); // Unten links
+    fillCircleQuadrant(x + r, y + r, r, 0x8 | 0x80); // Oben links
+
+    // Aktualisierung des gezeichneten Bereichs
+    startWrite();
+    setAddrWindow(x, y, w, h);
+    for(int16_t j = y; j < y + h; j++) {
+        writePixels(m_framebuffer[0] + j * m_h_res + x, w);
+    }
     endWrite();
 }
 //——————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————
-void TFT_SPI::drawCircle(int16_t x0, int16_t y0, int16_t r, uint16_t color) {
+void TFT_SPI::drawCircle(int16_t cx, int16_t cy, int16_t r, uint16_t color) {
+    if (cx + r < 0 || cx - r >= m_h_res || cy + r < 0 || cy - r >= m_v_res) {
+        return; // Kreis liegt komplett außerhalb, also nichts zeichnen
+    }
+    // Bresenham-Algorithmus für Kreise
     int16_t f = 1 - r;
     int16_t ddF_x = 1;
     int16_t ddF_y = -2 * r;
     int16_t x = 0;
     int16_t y = r;
 
-    startWrite();
-    writePixel(x0, y0 + r, color);
-    writePixel(x0, y0 - r, color);
-    writePixel(x0 + r, y0, color);
-    writePixel(x0 - r, y0, color);
+    // Setze die Anfangspunkte (Symmetrieachsen)
+    m_framebuffer[0][(cy + r) * m_h_res + cx] = color; // Oben
+    m_framebuffer[0][(cy - r) * m_h_res + cx] = color; // Unten
+    m_framebuffer[0][cy * m_h_res + (cx + r)] = color; // Rechts
+    m_framebuffer[0][cy * m_h_res + (cx - r)] = color; // Links
 
-    while(x < y) {
-        if(f >= 0) {
+    while (x < y) {
+        if (f >= 0) {
             y--;
             ddF_y += 2;
             f += ddF_y;
@@ -1299,14 +1457,23 @@ void TFT_SPI::drawCircle(int16_t x0, int16_t y0, int16_t r, uint16_t color) {
         ddF_x += 2;
         f += ddF_x;
 
-        writePixel(x0 + x, y0 + y, color);
-        writePixel(x0 - x, y0 + y, color);
-        writePixel(x0 + x, y0 - y, color);
-        writePixel(x0 - x, y0 - y, color);
-        writePixel(x0 + y, y0 + x, color);
-        writePixel(x0 - y, y0 + x, color);
-        writePixel(x0 + y, y0 - x, color);
-        writePixel(x0 - y, y0 - x, color);
+        // Punkte in den acht Symmetrieachsen zeichnen
+        m_framebuffer[0][(cy + y) * m_h_res + (cx + x)] = color; // Quadrant 1
+        m_framebuffer[0][(cy + y) * m_h_res + (cx - x)] = color; // Quadrant 2
+        m_framebuffer[0][(cy - y) * m_h_res + (cx + x)] = color; // Quadrant 3
+        m_framebuffer[0][(cy - y) * m_h_res + (cx - x)] = color; // Quadrant 4
+        m_framebuffer[0][(cy + x) * m_h_res + (cx + y)] = color; // Quadrant 5
+        m_framebuffer[0][(cy + x) * m_h_res + (cx - y)] = color; // Quadrant 6
+        m_framebuffer[0][(cy - x) * m_h_res + (cx + y)] = color; // Quadrant 7
+        m_framebuffer[0][(cy - x) * m_h_res + (cx - y)] = color; // Quadrant 8
+
+    }
+
+    // Aktualisierung des gezeichneten Bereichs
+    startWrite();
+    setAddrWindow(cx - r, cy - r, 2 * r + 1, 2 * r + 1);
+    for(int16_t j = cy - r; j <= cy + r; j++) {
+        writePixels(m_framebuffer[0] + j * m_h_res + cx - r, 2 * r + 1);
     }
     endWrite();
 }

--- a/lib/tftLib/tft_spi.cpp
+++ b/lib/tftLib/tft_spi.cpp
@@ -750,215 +750,6 @@ void TFT_SPI::setAddrWindow(uint16_t x, uint16_t y, uint16_t w, uint16_t h) {
     }
 }
 //——————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————
-void TFT_SPI::readAddrWindow(uint16_t x, uint16_t y, uint16_t w, uint16_t h) {
-    if(_TFTcontroller == ILI9341) { // ILI9341
-        uint32_t xa = ((uint32_t)x << 16) | (x + w - 1);
-        uint32_t ya = ((uint32_t)y << 16) | (y + h - 1);
-        writeCommand(ILI9341_CASET);
-        spi_TFT.write32(xa);
-        writeCommand(ILI9341_RASET);
-        spi_TFT.write32(ya);
-        writeCommand(ILI9341_RAMRD);
-    }
-    if(_TFTcontroller == HX8347D) { // HX8347D
-        writeCommand(0x02);
-        spi_TFT.write(x >> 8);
-        writeCommand(0x03);
-        spi_TFT.write(x & 0xFF); // Column Start
-        writeCommand(0x04);
-        spi_TFT.write((x + w - 1) >> 8);
-        writeCommand(0x05);
-        spi_TFT.write((x + w - 1) & 0xFF); // Column End
-        writeCommand(0x06);
-        spi_TFT.write(y >> 8);
-        writeCommand(0x07);
-        spi_TFT.write(y & 0xFF); // Row Start
-        writeCommand(0x08);
-        spi_TFT.write((y + h - 1) >> 8);
-        writeCommand(0x09);
-        spi_TFT.write((y + h - 1) & 0xFF); // Row End
-    }
-    if(_TFTcontroller == ILI9486a || _TFTcontroller == ILI9486b) {
-        writeCommand(ILI9486_CASET); // Column addr set
-        spi_TFT.write16(x >> 8);
-        spi_TFT.write16(x & 0xFF); // XSTART
-        w = x + w - 1;
-        spi_TFT.write16(w >> 8);
-        spi_TFT.write16(w & 0xFF);  // XEND
-        writeCommand(ILI9486_PASET); // Row addr set
-        spi_TFT.write16(y >> 8);
-        spi_TFT.write16(y & 0xFF); // YSTART
-        h = y + h - 1;
-        spi_TFT.write16(h >> 8);
-        spi_TFT.write16(h & 0xFF); // YEND
-        writeCommand(ILI9486_RAMRD);
-    }
-    if(_TFTcontroller == ILI9488) {
-        writeCommand(ILI9488_CASET); // Column addr set
-        spi_TFT.write(x >> 8);
-        spi_TFT.write(x & 0xFF); // XSTART
-        w = x + w - 1;
-        spi_TFT.write(w >> 8);
-        spi_TFT.write(w & 0xFF);    // XEND
-        writeCommand(ILI9488_PASET); // Row addr set
-        spi_TFT.write(y >> 8);
-        spi_TFT.write(y & 0xFF); // YSTART
-        h = y + h - 1;
-        spi_TFT.write(h >> 8);
-        spi_TFT.write(h & 0xFF); // YEND
-        writeCommand(ILI9488_RAMRD);
-    }
-    if(_TFTcontroller == ST7796) {
-        writeCommand(ST7796_CASET); // Column addr set
-        spi_TFT.write(x >> 8);
-        spi_TFT.write(x & 0xFF); // XSTART
-        w = x + w - 1;
-        spi_TFT.write(w >> 8);
-        spi_TFT.write(w & 0xFF);   // XEND
-        writeCommand(ST7796_RASET); // Row addr set
-        spi_TFT.write(y >> 8);
-        spi_TFT.write(y & 0xFF); // YSTART
-        h = y + h - 1;
-        spi_TFT.write(h >> 8);
-        spi_TFT.write(h & 0xFF); // YEND
-        writeCommand(ST7796_RAMRD);
-    }
-    if(_TFTcontroller == ST7796RPI) {
-        writeCommand(ST7796_CASET); // Column addr set
-        spi_TFT.write16(x >> 8);
-        spi_TFT.write16(x & 0xFF); // XSTART
-        w = x + w - 1;
-        spi_TFT.write16(w >> 8);
-        spi_TFT.write16(w & 0xFF); // XEND
-        writeCommand(ST7796_RASET); // Row addr set
-        spi_TFT.write16(y >> 8);
-        spi_TFT.write16(y & 0xFF); // YSTART
-        h = y + h - 1;
-        spi_TFT.write16(h >> 8);
-        spi_TFT.write16(h & 0xFF); // YEND
-        writeCommand(ST7796_RAMRD);
-    }
-}
-//——————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————
-void TFT_SPI::startBitmap(uint16_t x, uint16_t y, uint16_t w, uint16_t h) {
-
-    startWrite();
-    if(_TFTcontroller == ILI9341) { // ILI9341
-        writeCommand(ILI9341_MADCTL);
-        spi_TFT.write(ili9341_rotations[_rotation].bmpctl);
-    }
-    setAddrWindow(x, m_v_res - y - h, w, h);
-    // if(_TFTcontroller == HX8347D) { // HX8347D
-    //     if(_rotation == 0) {
-    //         writeCommand(0x16);
-    //         spi_TFT.write(0x88);
-    //     } // 0
-    //     if(_rotation == 1) {
-    //         writeCommand(0x16);
-    //         spi_TFT.write(0x38);
-    //     } // 90
-    //     if(_rotation == 2) {
-    //         writeCommand(0x16);
-    //         spi_TFT.write(0x48);
-    //     } // 180
-    //     if(_rotation == 3) {
-    //         writeCommand(0x16);
-    //         spi_TFT.write(0xE8);
-    //     } // 270
-    //     writeCommand(0x22);
-    // }
-    // if(_TFTcontroller == ILI9486a || _TFTcontroller == ILI9486b) {
-    //     writeCommand(ILI9486_MADCTL);
-    //     if(_rotation == 0) { spi_TFT.write16(ILI9486_MADCTL_MX | ILI9486_MADCTL_MY | ILI9486_MADCTL_ML | ILI9486_MADCTL_BGR); }
-    //     if(_rotation == 1) { spi_TFT.write16(ILI9486_MADCTL_MH | ILI9486_MADCTL_MV | ILI9486_MADCTL_MX | ILI9486_MADCTL_BGR); }
-    //     if(_rotation == 2) { spi_TFT.write16(ILI9486_MADCTL_MH | ILI9486_MADCTL_BGR); }
-    //     if(_rotation == 3) { spi_TFT.write16(ILI9486_MADCTL_MV | ILI9486_MADCTL_MY | ILI9486_MADCTL_BGR); }
-    //     writeCommand(ILI9486_RAMWR);
-    // }
-    // if(_TFTcontroller == ILI9488) {
-    //     writeCommand(ILI9488_MADCTL);
-    //     if(_rotation == 0) { spi_TFT.write(ILI9488_MADCTL_MX | ILI9488_MADCTL_MY | ILI9488_MADCTL_ML | ILI9488_MADCTL_BGR); }
-    //     if(_rotation == 1) { spi_TFT.write(ILI9488_MADCTL_MH | ILI9488_MADCTL_MV | ILI9488_MADCTL_MX | ILI9488_MADCTL_BGR); }
-    //     if(_rotation == 2) { spi_TFT.write(ILI9488_MADCTL_MH | ILI9488_MADCTL_BGR); }
-    //     if(_rotation == 3) { spi_TFT.write(ILI9488_MADCTL_MV | ILI9488_MADCTL_MY | ILI9488_MADCTL_BGR); }
-    //     writeCommand(ILI9488_RAMWR);
-    // }
-    // if(_TFTcontroller == ST7796) {
-    //     writeCommand(ST7796_MADCTL);
-    //     if(_rotation == 0) { spi_TFT.write(ST7796_MADCTL_MX | ST7796_MADCTL_MY | ST7796_MADCTL_ML | ST7796_MADCTL_BGR); }
-    //     if(_rotation == 1) { spi_TFT.write(ST7796_MADCTL_MH | ST7796_MADCTL_MV | ST7796_MADCTL_MX | ST7796_MADCTL_BGR); }
-    //     if(_rotation == 2) { spi_TFT.write(ST7796_MADCTL_MH | ST7796_MADCTL_BGR); }
-    //     if(_rotation == 3) { spi_TFT.write(ST7796_MADCTL_MV | ST7796_MADCTL_MY | ST7796_MADCTL_BGR); }
-    //     writeCommand(ST7796_RAMWR);
-    // }
-    // if(_TFTcontroller == ST7796RPI) {
-    //     writeCommand(ST7796_MADCTL);
-    //     if(_rotation == 0) { spi_TFT.write16(ST7796_MADCTL_MX | ST7796_MADCTL_MY | ST7796_MADCTL_ML | ST7796_MADCTL_BGR); }
-    //     if(_rotation == 1) { spi_TFT.write16(ST7796_MADCTL_MH | ST7796_MADCTL_MV | ST7796_MADCTL_MX | ST7796_MADCTL_BGR); }
-    //     if(_rotation == 2) { spi_TFT.write16(ST7796_MADCTL_MH | ST7796_MADCTL_BGR); }
-    //     if(_rotation == 3) { spi_TFT.write16(ST7796_MADCTL_MV | ST7796_MADCTL_MY | ST7796_MADCTL_BGR); }
-    //     writeCommand(ST7796_RAMWR);
-    // }
-    endWrite();
-}
-//——————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————
-void TFT_SPI::endBitmap() {
-    if(_TFTcontroller == ILI9341) { // ILI9341
-        startWrite();
-        writeCommand(ILI9341_MADCTL);
-        spi_TFT.write(ili9341_rotations[_rotation].madctl);
-        // setAddrWindow(x, m_h_res - y - h, w, h);
-        endWrite();
-    }
-    if(_TFTcontroller == HX8347D) { // HX8347D
-        setRotation(_rotation);     // return to old values
-    }
-    if(_TFTcontroller == ILI9486a || _TFTcontroller == ILI9486b) { setRotation(_rotation); }
-    if(_TFTcontroller == ILI9488) { setRotation(_rotation); }
-    if(_TFTcontroller == ST7796 || _TFTcontroller == ST7796RPI) { setRotation(_rotation); }
-}
-//——————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————
-void TFT_SPI::startJpeg() {
-    startWrite();
-    if(_TFTcontroller == ILI9341) { // ILI9341
-        writeCommand(ILI9341_MADCTL);
-    }
-    if(_TFTcontroller == HX8347D) { // HX8347D
-        // nothing to do
-    }
-    if(_TFTcontroller == ILI9486a || _TFTcontroller == ILI9486b) {
-        writeCommand(ILI9486_MADCTL);
-        if(_rotation == 0) { spi_TFT.write16(ILI9486_MADCTL_MH | ILI9486_MADCTL_MX | ILI9486_MADCTL_BGR); }
-        if(_rotation == 1) { spi_TFT.write16(ILI9486_MADCTL_MV | ILI9486_MADCTL_BGR); }
-        if(_rotation == 2) { spi_TFT.write16(ILI9486_MADCTL_MY | ILI9486_MADCTL_BGR); }
-        if(_rotation == 3) { spi_TFT.write16(ILI9486_MADCTL_MV | ILI9486_MADCTL_MY | ILI9486_MADCTL_MX | ILI9486_MADCTL_BGR); }
-    }
-    if(_TFTcontroller == ILI9488) {
-        writeCommand(ILI9488_MADCTL);
-        if(_rotation == 0) { spi_TFT.write(ILI9488_MADCTL_MH | ILI9488_MADCTL_MX | ILI9488_MADCTL_BGR); }
-        if(_rotation == 1) { spi_TFT.write(ILI9488_MADCTL_MV | ILI9488_MADCTL_BGR); }
-        if(_rotation == 2) { spi_TFT.write(ILI9488_MADCTL_MY | ILI9488_MADCTL_BGR); }
-        if(_rotation == 3) { spi_TFT.write(ILI9488_MADCTL_MV | ILI9488_MADCTL_MY | ILI9488_MADCTL_MX | ILI9488_MADCTL_BGR); }
-    }
-    if(_TFTcontroller == ST7796) {
-        writeCommand(ST7796_MADCTL);
-        if(_rotation == 0) { spi_TFT.write(ST7796_MADCTL_MH | ST7796_MADCTL_MX | ST7796_MADCTL_BGR); }
-        if(_rotation == 1) { spi_TFT.write(ST7796_MADCTL_MV | ST7796_MADCTL_BGR); }
-        if(_rotation == 2) { spi_TFT.write(ST7796_MADCTL_MY | ST7796_MADCTL_BGR); }
-        if(_rotation == 3) { spi_TFT.write(ST7796_MADCTL_MV | ST7796_MADCTL_MY | ST7796_MADCTL_MX | ST7796_MADCTL_BGR); }
-    }
-    if(_TFTcontroller == ST7796RPI) {
-        writeCommand(ST7796_MADCTL);
-        if(_rotation == 0) { spi_TFT.write16(ST7796_MADCTL_MH | ST7796_MADCTL_MX | ST7796_MADCTL_BGR); }
-        if(_rotation == 1) { spi_TFT.write16(ST7796_MADCTL_MV | ST7796_MADCTL_BGR); }
-        if(_rotation == 2) { spi_TFT.write16(ST7796_MADCTL_MY | ST7796_MADCTL_BGR); }
-        if(_rotation == 3) { spi_TFT.write16(ST7796_MADCTL_MV | ST7796_MADCTL_MY | ST7796_MADCTL_MX | ST7796_MADCTL_BGR); }
-    }
-    endWrite();
-}
-//——————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————
-void TFT_SPI::endJpeg() { setRotation(_rotation); }
-//——————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————
 void TFT_SPI::writePixels(uint16_t* colors, uint32_t len) {
     if((_TFTcontroller == ILI9488) || (_TFTcontroller == ST7796)) {
         uint32_t i = 0;
@@ -1021,59 +812,6 @@ void TFT_SPI::writePixel(int16_t x, int16_t y, uint16_t color) {
             break;
     }
 }
-//——————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————
-void TFT_SPI::writeFillRect(int16_t x, int16_t y, int16_t w, int16_t h, uint16_t color) {
-    if((x >= m_h_res) || (y >= m_v_res)) return;
-    int16_t x2 = x + w - 1, y2 = y + h - 1;
-    if((x2 < 0) || (y2 < 0)) return;
-
-    // Clip left/top
-    if(x < 0) {
-        x = 0;
-        w = x2 + 1;
-    }
-    if(y < 0) {
-        y = 0;
-        h = y2 + 1;
-    }
-
-    // Clip right/bottom
-    if(x2 >= m_h_res) w = m_h_res - x;
-    if(y2 >= m_v_res) h = m_v_res - y;
-
-    int32_t len = (int32_t)w * h;
-    setAddrWindow(x, y, w, h);
-    if(_TFTcontroller == HX8347D) writeCommand(0x22);
-    if(_TFTcontroller == ILI9486a || _TFTcontroller == ILI9486b) writeCommand(ILI9486_RAMWR);
-    if(_TFTcontroller == ILI9488) writeCommand(ILI9488_RAMWR);
-    if(_TFTcontroller == ST7796 || _TFTcontroller == ST7796RPI) writeCommand(ST7796_RAMWR);
-    writeColor(color, len);
-}
-//——————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————
-void TFT_SPI::writeFastVLine(int16_t x, int16_t y, int16_t h, uint16_t color) { writeFillRect(x, y, 1, h, color); }
-//——————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————
-void TFT_SPI::writeFastHLine(int16_t x, int16_t y, int16_t w, uint16_t color) { writeFillRect(x, y, w, 1, color); }
-//——————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————
-uint8_t TFT_SPI::readcommand8(uint8_t c, uint8_t index) {
-    uint32_t freq = _freq;
-    if(_freq > 24000000) { _freq = 24000000; }
-    startWrite();
-    writeCommand(0xD9); // woo sekret command?
-    spi_TFT.write(0x10 + index);
-    writeCommand(c);
-    uint8_t r = spi_TFT.transfer(0);
-    endWrite();
-    _freq = freq;
-    return r;
-}
-//——————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————
-void TFT_SPI::drawPixel(int16_t x, int16_t y, uint16_t color) {
-    startWrite();
-    writePixel(x, y, color);
-    endWrite();
-}
-//——————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————
-uint16_t TFT_SPI::color565(uint8_t r, uint8_t g, uint8_t b) { return ((r & 0xF8) << 8) | ((g & 0xFC) << 3) | (b >> 3); }
 //——————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————
 void TFT_SPI::fillRect(int16_t x, int16_t y, int16_t w, int16_t h, uint16_t color) {
     // Clipping: Rechteck-Koordinaten auf den Framebuffer-Bereich beschränken
@@ -1431,8 +1169,10 @@ void TFT_SPI::drawCircle(int16_t cx, int16_t cy, int16_t r, uint16_t color) {
     endWrite();
 }
 //——————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————
-void TFT_SPI::fillCircle(int16_t Xm, int16_t Ym, uint16_t r, uint16_t color){
-//void TFT_RGB::drawFilledCircle(int16_t cx, int16_t cy, int16_t r, uint16_t color) {
+void TFT_SPI::fillCircle(int16_t cx, int16_t cy, uint16_t r, uint16_t color){
+    if (cx + r < 0 || cx - r >= m_h_res || cy + r < 0 || cy - r >= m_v_res) {
+        return; // Circle is completely outside, so don't draw anything
+    }
     // Bresenham-Algorithmus für Kreise
     int16_t f = 1 - r;
     int16_t ddF_x = 1;
@@ -1440,20 +1180,27 @@ void TFT_SPI::fillCircle(int16_t Xm, int16_t Ym, uint16_t r, uint16_t color){
     int16_t x = 0;
     int16_t y = r;
 
+
+    auto setPixelSafe = [&](int16_t x, int16_t y, uint16_t color) {
+        if (x >= 0 && x < m_h_res && y >= 0 && y < m_v_res) {
+            m_framebuffer[0][y * m_h_res + x] = color;
+        }
+    };
+
     // Fülle die erste vertikale Linie durch den Mittelpunkt
-    for (int16_t i = Ym - r; i <= Ym + r; i++) {
-        m_framebuffer[0][i * m_h_res + Xm] = color;
+    for (int16_t i = cy - r; i <= cy + r; i++) {
+        setPixelSafe(cx, i, color);
     }
 
     while (x <= y) {
         // Fülle horizontale Linien für alle acht Symmetrieachsen
-        for (int16_t i = Xm - x; i <= Xm + x; i++) {
-            m_framebuffer[0][(Ym + y) * m_h_res + i] = color; // Unten +y
-            m_framebuffer[0][(Ym - y) * m_h_res + i] = color; // Oben -y
+        for (int16_t i = cx - x; i <= cx + x; i++) {
+            setPixelSafe(i, cy + y, color); // Unten +y
+            setPixelSafe(i, cy - y, color); // Oben -y
         }
-        for (int16_t i = Xm - y; i <= Xm + y; i++) {
-            m_framebuffer[0][(Ym + x) * m_h_res + i] = color; // Rechts +x
-            m_framebuffer[0][(Ym - x) * m_h_res + i] = color; // Links -x
+        for (int16_t i = cx - y; i <= cx + y; i++) {
+            setPixelSafe(i, cy + x, color); // Rechts +x
+            setPixelSafe(i, cy - x, color); // Links -x
         }
 
         if (f >= 0) {
@@ -1467,10 +1214,16 @@ void TFT_SPI::fillCircle(int16_t Xm, int16_t Ym, uint16_t r, uint16_t color){
     }
 
     // Update of the drawn area
+    int16_t x1 = std::max(cx - r, 1) - 1;
+    int16_t y1 = std::max(cy - r, 1) - 1;
+    int16_t w1 = std::min(cx + r, m_h_res - 1) - x1 + 1;
+    int16_t h1 = std::min(cy + r, m_v_res - 1) - y1 + 1;
+
+    // Update of the drawn area
     startWrite();
-    setAddrWindow(Xm - r, Ym - r, Xm + r + 1, Ym + r + 1);
-    for(int16_t j = Ym - r; j <= Ym + r + 1; j++) {
-        writePixels(m_framebuffer[0] + j * m_h_res + Xm - r, Xm + r);
+    setAddrWindow(x1, y1, w1, h1);
+    for(int16_t j = y1; j <= y1 + h1; j++) {
+        writePixels(m_framebuffer[0] + j * m_h_res + x1, w1);
     }
     endWrite();
 }
@@ -2180,9 +1933,7 @@ void TFT_SPI::setFont(uint16_t font) {
  *                                                                                                                                                                                                     *
  * *****************************************************************************************************************************************************************************************************
  */
-void TFT_SPI::writeInAddrWindow(const uint8_t* bmi, uint16_t posX, uint16_t poxY, uint16_t width, uint16_t height) {
-
-    uint16_t nrOfPixels = width * height;
+void TFT_SPI::writeInAddrWindow(const uint8_t* bmi, uint16_t posX, uint16_t posY, uint16_t width, uint16_t height) {
 
     auto bitreader = [&](const uint8_t* bm) { // lambda
         static uint16_t       bmi = 0;
@@ -2192,7 +1943,7 @@ void TFT_SPI::writeInAddrWindow(const uint8_t* bmi, uint16_t posX, uint16_t poxY
             bitmap = bm;
             idx = 0x80;
             bmi = 0;
-            return (uint16_t)0;
+            return (int32_t)0;
         }
         bool bit = *(bitmap + bmi) & idx;
         idx >>= 1;
@@ -2200,33 +1951,26 @@ void TFT_SPI::writeInAddrWindow(const uint8_t* bmi, uint16_t posX, uint16_t poxY
             bmi++;
             idx = 0x80;
         }
-        if(bit) { return _textColor; }
-        return _backGroundColor;
+        if(bit) { return (int32_t) _textColor;}
+        return (int32_t)-1;  // _backColor, -1 is transparent
     };
 
     bitreader(bmi);
 
+    for(int16_t j = posY; j < posY + height; j++) {
+        for(int16_t i = posX; i < posX + width; i++) {
+            int32_t color = bitreader(0);
+            if(color == -1) {
+                continue;
+            }
+            m_framebuffer[0][j * m_h_res + i] = color;
+        }
+    }
+
     startWrite();
-    setAddrWindow(posX, poxY, width, height);
-    if(_TFTcontroller == ILI9341) {
-        writeCommand(ILI9341_RAMWR);                        // ILI9341
-        while(nrOfPixels--) spi_TFT.write16(bitreader(0)); // Send to TFT_SPI 16 bits at a time
-    }
-    else if(_TFTcontroller == HX8347D) {
-        writeCommand(0x22);
-        while(nrOfPixels--) spi_TFT.write16(bitreader(0)); // Send to TFT_SPI 16 bits at a time
-    }
-    else if(_TFTcontroller == ILI9486a || _TFTcontroller == ILI9486b) {
-        writeCommand(ILI9486_RAMWR);
-        while(nrOfPixels--) spi_TFT.write16(bitreader(0)); // Send to TFT_SPI 16 bits at a time
-    }
-    else if(_TFTcontroller == ILI9488) {
-        writeCommand(ILI9488_RAMWR);
-        while(nrOfPixels--) write24BitColor(bitreader(0)); // Send to TFT_SPI 16 bits at a time
-    }
-    else if(_TFTcontroller == ST7796 || _TFTcontroller == ST7796RPI) {
-        writeCommand(ST7796_RAMWR);
-        while(nrOfPixels--) write24BitColor(bitreader(0)); // Send to TFT_SPI 16 bits at a time
+    setAddrWindow(posX, posY, width, height);
+    for(int16_t j = posY; j < posY + height; j++) {
+        writePixels(m_framebuffer[0] + j * m_h_res + posX, width);
     }
     endWrite();
 }
@@ -3359,50 +3103,27 @@ bool TFT_SPI::GIF_ReadImage(uint16_t x, uint16_t y) {
         i++;
     }
 
+    // write to TFT
+    for (uint16_t row = 0; row < gif_ImageHeight; row++) {
+        for (uint16_t col = 0; col < gif_ImageWidth; col++) {
+            uint16_t fb_x = xpos + col; // calculate X position in framebuffer
+            uint16_t fb_y = ypos + row; // calculate Y position in framebuffer
+
+            // check if pixel is within the screen
+            if (fb_x < m_h_res && fb_y < m_v_res) {
+                m_framebuffer[0][fb_y * m_h_res + fb_x] = buf[row * gif_ImageWidth + col];
+            }
+        }
+    }
+
     startWrite();
     setAddrWindow(xpos, ypos, gif_ImageWidth, gif_ImageHeight);
-    if(_TFTcontroller == ILI9341) {
-        writeCommand(ILI9341_RAMWR); // ILI9341
-        goto write16;
-    }
-    else if(_TFTcontroller == HX8347D) {
-        writeCommand(0x22);
-        goto write16;
-    }
-    else if(_TFTcontroller == ILI9486a || _TFTcontroller == ILI9486b) {
-        writeCommand(ILI9486_RAMWR);
-        goto write16;
-    }
-    else if(_TFTcontroller == ILI9488) {
-        writeCommand(ILI9488_RAMWR);
-        goto write24;
-    }
-    else if(_TFTcontroller == ST7796 || _TFTcontroller == ST7796RPI) {
-        writeCommand(ST7796_RAMWR);
-        goto write24;
-    }
-
-write16:
-    i = 0;
-    while(i < max) {
-        spi_TFT.write16(buf[i]);
-        i++;
+    for(int16_t j = y; j < ypos + gif_ImageHeight; j++) {
+        writePixels(m_framebuffer[0] + j * m_h_res + xpos, gif_ImageWidth);
     }
     endWrite();
-    if(buf) {
-        free(buf);
-        buf = NULL;
-    }
-    return true;
 
-write24:
-    i = 0;
-    while(i < max) {
-        write24BitColor(buf[i]);
-        i++;
-    }
-    endWrite();
-    if(buf) {
+    if (buf) {
         free(buf);
         buf = NULL;
     }
@@ -3467,9 +3188,17 @@ bool TFT_SPI::drawJpgFile(fs::FS& fs, const char* path, uint16_t x, uint16_t y, 
     m_jpgFile = fs.open(path, FILE_READ);
     if(!m_jpgFile) {log_e("Failed to open file for reading"); JPEG_setJpgScale(1); return false;}
     JPEG_getJpgSize(&m_jpgWidth, &m_jpgHeight);
-    int r = JPEG_drawJpg(x, y);
-    if(r) {log_e("JPEG_drawJpg failed with error %i", r); return false;}
+    int res = JPEG_drawJpg(x, y); (void) res;
+    // log_w("path %s, res %i, x %i, y %i, m_jpgWidth %i, m_jpgHeight %i", path, res, x, y, m_jpgWidth, m_jpgHeight);
     m_jpgFile.close();
+
+    startWrite();
+    setAddrWindow(x, y, m_jpgWidth, m_jpgHeight);
+    for(int16_t j = y; j < y + m_jpgHeight; j++) {
+        writePixels(m_framebuffer[0] + j * m_h_res + x, m_jpgWidth);
+    }
+    endWrite();
+
     return true;
 }
 //——————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————
@@ -3522,27 +3251,41 @@ int TFT_SPI::JPEG_jd_output(JDEC* jdec, void* bitmap, JRECT* jrect) {
 }
 //——————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————
 bool TFT_SPI::JPEG_tft_output(int16_t x, int16_t y, uint16_t w, uint16_t h, uint16_t* bitmap) {
-    int mcu_pixels = w * h; // Number of pixels in MCU block
-    startWrite();
-    setAddrWindow(x, y, w, h);
-    if (_TFTcontroller == ILI9341) {
-        writeCommand(ILI9341_RAMWR);                      // ILI9341
-        while (mcu_pixels--) spi_TFT.write16(*bitmap++); // Send to TFT_SPI 16 bits at a time
-    } else if (_TFTcontroller == HX8347D) {
-        writeCommand(0x22);
-        while (mcu_pixels--) spi_TFT.write16(*bitmap++); // Send to TFT_SPI 16 bits at a time
-    } else if (_TFTcontroller == ILI9486a || _TFTcontroller == ILI9486b) {
-        writeCommand(ILI9486_RAMWR);
-        while (mcu_pixels--) spi_TFT.write16(*bitmap++); // Send to TFT_SPI 16 bits at a time
-    } else if (_TFTcontroller == ILI9488) {
-        writeCommand(ILI9488_RAMWR);
-        while (mcu_pixels--) write24BitColor(*bitmap++); // Send to TFT_SPI 16 bits at a time
-    } else if (_TFTcontroller == ST7796 || _TFTcontroller == ST7796RPI) {
-        writeCommand(ST7796_RAMWR);
-        while (mcu_pixels--) write24BitColor(*bitmap++); // Send to TFT_SPI 16 bits at a time
+      if (!bitmap || w <= 0 || h <= 0) {  // Check for valid parameters
+        log_e("Invalid parameters: bitmap is null or width/height is zero.");
+        return false;
     }
-    endWrite();
+    // Clip the rectangle to ensure it doesn't exceed framebuffer boundaries
+    int16_t x_end = std::min((int16_t)(x + w), (int16_t)m_h_res); // End of rectangle in x-direction
+    int16_t y_end = std::min((int16_t)(y + h), (int16_t)(m_v_res)); // End of rectangle in y-direction
 
+    if (x >= m_h_res || y >= m_v_res || x_end <= 0 || y_end <= 0) {
+        log_e("Rectangle is completely outside the framebuffer boundaries.");
+        return false;
+    }
+
+    // Adjust start coordinates if they are out of bounds
+    int16_t start_x = max((int16_t)0, x);        // Sichtbarer Startpunkt in x-Richtung
+    int16_t start_y = max((int16_t)0, y);        // Sichtbarer Startpunkt in y-Richtung
+    int16_t clip_x_offset = start_x - x;         // Offset im Bitmap in x-Richtung
+    int16_t clip_y_offset = start_y - y;         // Offset im Bitmap in y-Richtung
+
+    // Berechnung der sichtbaren Breite und Höhe
+    int16_t visible_w = x_end - start_x;         // Sichtbare Breite
+    int16_t visible_h = y_end - start_y;         // Sichtbare Höhe
+
+    // Zeilenweises Kopieren mit Clipping
+    for (int16_t j = 0; j < visible_h ; ++j) {
+        // Quelle im Bitmap: Berechne die richtige Zeilenposition
+        uint16_t* src_ptr = bitmap + (clip_y_offset + j) * w + clip_x_offset;
+
+        // Ziel im Framebuffer: Berechne die richtige Zeilenposition
+        uint16_t* dest_ptr = m_framebuffer[0] + (start_y + j) * m_h_res + start_x;
+
+        // Kopiere nur die sichtbare Breite
+        memcpy(dest_ptr, src_ptr, visible_w * sizeof(uint16_t));
+    }
+    // log_w("Bitmap erfolgreich mit Clipping gezeichnet bei x: %d, y: %d, sichtbare Breite: %d, sichtbare Höhe: %d", start_x, start_y, visible_w, visible_h);
     return true;
 }
 //——————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————
@@ -5585,42 +5328,57 @@ void TFT_SPI::png_rgb18btouint32(uint32_t* dst, png_s_rgb18b* src) { memcpy(dst,
 void TFT_SPI::png_rgb16btouint32(uint32_t* dst, png_s_rgb16b* src) { memcpy(dst, src, sizeof(png_s_rgb16b)); }
 // —————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————
 void TFT_SPI::png_draw_into_AddrWindow(uint16_t x, uint16_t y, uint16_t w, uint16_t h, char* rgbaBuffer, uint32_t png_outbuff_size, uint8_t png_format) {
+    if (!rgbaBuffer || png_outbuff_size < w * h * 4) return; // not enough data
 
-    uint16_t* rgb565Buffer = (uint16_t*)ps_malloc(w * h * 2);
-    if(!rgb565Buffer) {log_e("png_draw_into_AddrWindow: out of memory"); return;}
+    for (uint16_t row = 0; row < h; row++) {
+        for (uint16_t col = 0; col < w; col++) {
+            uint32_t index = (row * w + col) * 4;
+            uint8_t r = rgbaBuffer[index];     // Rot
+            uint8_t g = rgbaBuffer[index + 1]; // Grün
+            uint8_t b = rgbaBuffer[index + 2]; // Blau
+            uint8_t a = rgbaBuffer[index + 3]; // Alpha
 
-    int numPixels = w * h;
+            uint16_t px = x + col;
+            uint16_t py = y + row;
 
-    for (int i = 0; i < numPixels; i++) {
-        int rgbaIndex = i * 4; // 4 Bytes pro Pixel (RGBA)
+            if (px >= m_h_res || py >= m_v_res) continue; // outside the screen
 
-        uint8_t r = rgbaBuffer[rgbaIndex];     // Rot (8 Bit)
-        uint8_t g = rgbaBuffer[rgbaIndex + 1]; // Grün (8 Bit)
-        uint8_t b = rgbaBuffer[rgbaIndex + 2]; // Blau (8 Bit)
+            // only alpha blending if alpha is not full
+            if (a < 255) {
+                // get the old pixel
+                uint16_t oldPixel = m_framebuffer[0][py * m_h_res + px];
 
-        // RGB565 Kodierung (5 Bit Rot, 6 Bit Grün, 5 Bit Blau)
-        rgb565Buffer[i] = ((r >> 3) << 11) |  // 8->5 Bit (Rot)
-                          ((g >> 2) << 5)  |  // 8->6 Bit (Grün)
-                          (b >> 3);         // 8->5 Bit (Blau)
+                // Extrahiere die RGB-Komponenten aus dem alten Pixel (RGB565 → 888)
+                uint8_t oldR = ((oldPixel >> 11) & 0x1F) << 3; // 5 Bit Rot → 8 Bit
+                uint8_t oldG = ((oldPixel >> 5) & 0x3F) << 2;  // 6 Bit Grün → 8 Bit
+                uint8_t oldB = (oldPixel & 0x1F) << 3;         // 5 Bit Blau → 8 Bit
+
+                // calculate the new pixel
+                uint8_t newR = (r * a + oldR * (255 - a)) / 255;
+                uint8_t newG = (g * a + oldG * (255 - a)) / 255;
+                uint8_t newB = (b * a + oldB * (255 - a)) / 255;
+
+                // set the new pixel in the framebuffer
+                r = newR >> 3;
+                g = newG >> 2;
+                b = newB >> 3;
+            } else {
+                // full alpha, no blending
+                r = r >> 3;
+                g = g >> 2;
+                b = b >> 3;
+            }
+
+            // set the new pixel in the framebuffer
+            m_framebuffer[0][py * m_h_res + px] = (r << 11) | (g << 5) | b;
+        }
     }
 
+    // update the display
     startWrite();
     setAddrWindow(x, y, w, h);
-    if (_TFTcontroller == ILI9341) {
-        writeCommand(ILI9341_RAMWR);                      // ILI9341
-        while (numPixels--) spi_TFT.write16(*rgb565Buffer++); // Send to TFT_SPI 16 bits at a time
-    } else if (_TFTcontroller == HX8347D) {
-        writeCommand(0x22);
-        while (numPixels--) spi_TFT.write16(*rgb565Buffer++); // Send to TFT_SPI 16 bits at a time
-    } else if (_TFTcontroller == ILI9486a || _TFTcontroller == ILI9486b) {
-        writeCommand(ILI9486_RAMWR);
-        while (numPixels--) spi_TFT.write16(*rgb565Buffer++); // Send to TFT_SPI 16 bits at a time
-    } else if (_TFTcontroller == ILI9488) {
-        writeCommand(ILI9488_RAMWR);
-        while (numPixels--) write24BitColor(*rgb565Buffer++); // Send to TFT_SPI 16 bits at a time
-    } else if (_TFTcontroller == ST7796 || _TFTcontroller == ST7796RPI) {
-        writeCommand(ST7796_RAMWR);
-        while (numPixels--) write24BitColor(*rgb565Buffer++); // Send to TFT_SPI 16 bits at a time
+    for(uint16_t row = y; row < y + h; row++) {
+        writePixels(m_framebuffer[0] + row * m_h_res + x, w);
     }
     endWrite();
 }

--- a/lib/tftLib/tft_spi.h
+++ b/lib/tftLib/tft_spi.h
@@ -266,9 +266,6 @@ class TFT_SPI {
     void scrollTo(uint16_t y);
 
     // Recommended Non-Transaction
-    void     drawLine(int16_t Xpos0, int16_t Ypos0, int16_t Xpos1, int16_t Ypos1, uint16_t color);
-    void     drawFastVLine(int16_t x, int16_t y, int16_t h, uint16_t color);
-    void     drawFastHLine(int16_t x, int16_t y, int16_t w, uint16_t color);
     void     drawRect(int16_t Xpos, int16_t Ypos, uint16_t Width, uint16_t Height, uint16_t Color);
     void     readRect(int32_t x, int32_t y, int32_t w, uint16_t* data);
     void     fillRect(int16_t x, int16_t y, int16_t w, int16_t h, uint16_t color);
@@ -452,47 +449,20 @@ class TFT_SPI {
     inline void TFT_CS_HIGH() { gpio_set_level((gpio_num_t)_TFT_CS, 1); }
     inline void TFT_CS_LOW() { gpio_set_level((gpio_num_t)_TFT_CS, 0); }
 
-    inline void _swap_int16_t(int16_t& a, int16_t& b) {
-        int16_t t = a;
-        a = b;
-        b = t;
-    }
     void     init();
     void     writeCommand(uint16_t cmd);
     uint16_t readCommand();
 
     // Transaction API not used by GFX
     void     setAddrWindow(uint16_t x, uint16_t y, uint16_t w, uint16_t h);
-    void     readAddrWindow(uint16_t x, uint16_t y, uint16_t w, uint16_t h);
     void     write24BitColor(uint16_t color);
     void     writePixels(uint16_t* colors, uint32_t len);
     void     writeColor(uint16_t color, uint32_t len);
-    uint16_t color565(uint8_t r, uint8_t g, uint8_t b);
-
-    // Required Non-Transaction
-    void drawPixel(int16_t x, int16_t y, uint16_t color);
 
     // Transaction API
     void startWrite(void);
     void endWrite(void);
     void writePixel(int16_t x, int16_t y, uint16_t color);
-    void writeFillRect(int16_t x, int16_t y, int16_t w, int16_t h, uint16_t color);
-    void writeFastVLine(int16_t x, int16_t y, int16_t h, uint16_t color);
-    void writeFastHLine(int16_t x, int16_t y, int16_t w, uint16_t color);
-
-    void fillCircleHelper(int16_t x0, int16_t y0, int16_t r, uint8_t cornername, int16_t delta, uint16_t color);
-    void drawCircleHelper(int16_t x0, int16_t y0, int16_t r, uint8_t cornername, uint16_t color);
-    void startBitmap(uint16_t x, uint16_t y, uint16_t w, uint16_t h);
-    void endBitmap();
-    void startJpeg();
-    void endJpeg();
-
-    void bmpSkipPixels(fs::File& file, uint8_t bitsPerPixel, size_t len);
-    void bmpAddPixels(fs::File& file, uint8_t bitsPerPixel, size_t len);
-    void drawBitmap(int16_t x, int16_t y, int16_t w, int16_t h, const uint16_t* pcolors);
-    void renderJPEG(int32_t xpos, int32_t ypos, uint16_t maxWidth, uint16_t maxHeight);
-
-    uint8_t readcommand8(uint8_t reg, uint8_t index = 0);
 
 // ——————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————
 //   ⏫⏫⏫⏫⏫⏫  ⏫⏫⏫⏫⏫⏫  ⏫⏫⏫⏫⏫⏫  ⏫⏫⏫⏫⏫⏫  ⏫⏫⏫⏫⏫⏫  ⏫⏫⏫⏫⏫⏫   J P E G   ⏫⏫⏫⏫⏫⏫  ⏫⏫⏫⏫⏫⏫  ⏫⏫⏫⏫⏫⏫  ⏫⏫⏫⏫⏫⏫  ⏫⏫⏫⏫⏫⏫ ⏫⏫⏫⏫⏫⏫  ⏫⏫⏫⏫⏫⏫

--- a/lib/tftLib/tft_spi.h
+++ b/lib/tftLib/tft_spi.h
@@ -256,7 +256,7 @@ class TFT_SPI {
 
   public:
     TFT_SPI(SPIClass& spi, int csPin);
-    virtual ~TFT_SPI() {}
+    ~TFT_SPI();
     void setTFTcontroller(uint8_t TFTcontroller);
     void setDiaplayInversion(uint8_t dispInv);
     void begin(uint8_t DC);
@@ -306,8 +306,8 @@ class TFT_SPI {
     SPIClass&   spi_TFT; // use in class TP
     uint16_t    m_h_res = 0;
     uint16_t    m_v_res = 0;
-    uint16_t*   m_framebuffer;
-
+    uint16_t*   m_framebuffer[2];
+    bool        m_framebuffer_index = 0;
     uint8_t fontSizes[11] = {15, 16, 18, 21, 25, 27, 34, 38, 43, 56, 66};
 
     typedef struct {

--- a/lib/tftLib/tft_spi.h
+++ b/lib/tftLib/tft_spi.h
@@ -270,7 +270,7 @@ class TFT_SPI {
     void     drawFastVLine(int16_t x, int16_t y, int16_t h, uint16_t color);
     void     drawFastHLine(int16_t x, int16_t y, int16_t w, uint16_t color);
     void     drawRect(int16_t Xpos, int16_t Ypos, uint16_t Width, uint16_t Height, uint16_t Color);
-    void     readRect(int32_t x, int32_t y, int32_t w, int32_t h, uint16_t* data);
+    void     readRect(int32_t x, int32_t y, int32_t w, uint16_t* data);
     void     fillRect(int16_t x, int16_t y, int16_t w, int16_t h, uint16_t color);
     void     drawRoundRect(int16_t x, int16_t y, int16_t w, int16_t h, int16_t r, uint16_t color);
     void     fillRoundRect(int16_t x, int16_t y, int16_t w, int16_t h, int16_t r, uint16_t color);
@@ -279,7 +279,7 @@ class TFT_SPI {
     void     fillTriangle(int16_t x0, int16_t y0, int16_t x1, int16_t y1, int16_t x2, int16_t y2, uint16_t color);
     void     drawCircle(int16_t x0, int16_t y0, int16_t r, uint16_t color);
     void     fillCircle(int16_t Xm, int16_t Ym, uint16_t r, uint16_t color);
-    bool     drawBmpFile(fs::FS& fs, const char* path, uint16_t x = 0, uint16_t y = 0, uint16_t maxWidth = 0, uint16_t maxHeight = 0, uint16_t offX = 0, uint16_t offY = 0);
+    bool     drawBmpFile(fs::FS& fs, const char* path, uint16_t x, uint16_t y, uint16_t maxWidth, uint16_t maxHeight, float scale);
     bool     drawGifFile(fs::FS& fs, const char* path, uint16_t x, uint16_t y, uint8_t repeat);
     bool     drawJpgFile(fs::FS& fs, const char* path, uint16_t x = 0, uint16_t y = 0, uint16_t maxWidth = 0, uint16_t maxHeight = 0);
     void     writeInAddrWindow(const uint8_t* bmi, uint16_t posX, uint16_t poxY, uint16_t width, uint16_t height);

--- a/src/common.h
+++ b/src/common.h
@@ -7,11 +7,11 @@
 #define _SSID                   "mySSID"                        // Your WiFi credentials here
 #define _PW                     "myWiFiPassword"                // Or in textfile on SD-card
 #define DECODER                 1                               // (1)MAX98357A PCM5102A CS4344... (2)AC101, (3)ES8388
-#define TFT_CONTROLLER          5                               // (0)ILI9341, (1)HX8347D, (2)ILI9486a, (3)ILI9486b, (4)ILI9488, (5)ST7796, (6)ST7796RPI
+#define TFT_CONTROLLER          4                               // (0)ILI9341, (1)HX8347D, (2)ILI9486a, (3)ILI9486b, (4)ILI9488, (5)ST7796, (6)ST7796RPI
 #define DISPLAY_INVERSION       0                               // (0) off (1) on
 #define TFT_ROTATION            1                               // 1 or 3 (landscape)
 #define TFT_FREQUENCY           40000000                        // 80000000, 40000000, 27000000, 20000000, 10000000
-#define TP_VERSION              5                               // (0)ILI9341, (1)ILI9341RPI, (2)HX8347D, (3)ILI9486, (4)ILI9488, (5)ST7796, (6)ST7796RPI, (7)GT911
+#define TP_VERSION              4                               // (0)ILI9341, (1)ILI9341RPI, (2)HX8347D, (3)ILI9486, (4)ILI9488, (5)ST7796, (6)ST7796RPI, (7)GT911
 #define TP_ROTATION             1                               // 1 or 3 (landscape)
 #define TP_H_MIRROR             0                               // (0) default, (1) mirror up <-> down
 #define TP_V_MIRROR             0                               // (0) default, (1) mittor left <-> right
@@ -1403,7 +1403,7 @@ private:
     }
     void drawNewSpot(uint16_t xPos){
         if(m_enabled){
-            tft.fillRect(m_spotPos - m_spotRadius, m_middle_h - m_spotRadius,     2 * m_spotRadius, 2 * m_spotRadius, m_bgColor);
+            tft.fillRect(m_spotPos - m_spotRadius, m_middle_h - m_spotRadius,     2 * m_spotRadius, 2 * m_spotRadius + 1, m_bgColor);
             tft.fillRect(m_spotPos - m_spotRadius, m_middle_h - (m_railHigh / 2), 2 * m_spotRadius + 1, m_railHigh,   m_railColor);
             tft.fillCircle(xPos, m_middle_h, m_spotRadius, m_spotColor);
         }

--- a/src/common.h
+++ b/src/common.h
@@ -569,7 +569,7 @@ inline void hardcopy(){
         hc.write(bmp320x240, sizeof(bmp320x240));
         uint16_t buff[320];
         for(int i = 240; i > 0; i--){
-            tft.readRect(0, i - 1, 320, 1, buff);
+            tft.readRect(0, i - 1, 320, buff);
             hc.write((uint8_t*)buff, 320 * 2);
         }
         hc.close();
@@ -578,7 +578,7 @@ inline void hardcopy(){
         hc.write(bmp480x320, sizeof(bmp480x320));
         uint16_t buff[480];
         for(int i = 320; i > 0; i--){
-            tft.readRect(0, i - 1, 480, 1, buff);
+            tft.readRect(0, i - 1, 480, buff);
             hc.write((uint8_t*)buff, 480 * 2);
         }
         hc.close();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1510,6 +1510,8 @@ void setup() {
     if(TFT_CONTROLLER > 6) SerialPrintfln(ANSI_ESC_RED "The value in TFT_CONTROLLER is invalid");
 
     drawImage("/common/MiniWebRadioV3.jpg", 0, 0); // Welcomescreen
+    tft.drawLine(0, 0, 400, 300, TFT_GREEN); // clear line
+    vTaskDelay(2000 / portTICK_PERIOD_MS);
     updateSettings();
     if(_brightness < 5) _brightness = 5;
     if(_volumeSteps < 21) _volumeSteps = 21;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1515,13 +1515,6 @@ void setup() {
     if(_brightness < 5) _brightness = 5;
     if(_volumeSteps < 21) _volumeSteps = 21;
     setTFTbrightness(_brightness);
-    tft.drawTriangle(0, 0, 479, 0, 479, 319, TFT_RED);
-    tft.fillTriangle(0, 0, 479, 0, 479, 319, TFT_RED);
-    tft.drawRect(0, 0, 480, 320, TFT_WHITE);
-    tft.drawRoundRect(0, 0, 480, 320, 30, TFT_YELLOW);
-    tft.fillRoundRect(0, 0, 480, 320, 60, TFT_GREEN);
-    tft.drawCircle(240, 160, 120, TFT_BLACK);
-    tft.fillCircle(240, 160, 100, TFT_WHITE);
     vTaskDelay(2000 / portTICK_PERIOD_MS);
     SerialPrintfln("setup: ....  seek for WiFi networks");
     if(!connectToWiFi()){

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -902,7 +902,7 @@ boolean drawImage(const char* path, uint16_t posX, uint16_t posY, uint16_t maxWi
         SerialPrintfln("AUDIO_info:  " ANSI_ESC_RED "file \"%s\" not found", scImg);
         return false;
     }
-    if(endsWith(scImg, "bmp")) { return tft.drawBmpFile(SD_MMC, scImg, posX, posY, maxWidth, maxHeigth); }
+    if(endsWith(scImg, "bmp")) { return tft.drawBmpFile(SD_MMC, scImg, posX, posY, maxWidth, maxHeigth, 1.0); }
     if(endsWith(scImg, "jpg")) { return tft.drawJpgFile(SD_MMC, scImg, posX, posY, maxWidth, maxHeigth); }
     if(endsWith(scImg, "gif")) { return tft.drawGifFile(SD_MMC, scImg, posX, posY, 0); }
 
@@ -1520,7 +1520,8 @@ void setup() {
     tft.drawRect(0, 0, 480, 320, TFT_WHITE);
     tft.drawRoundRect(0, 0, 480, 320, 30, TFT_YELLOW);
     tft.fillRoundRect(0, 0, 480, 320, 60, TFT_GREEN);
-    tft.drawCircle(240, 160, 20, TFT_BLACK);
+    tft.drawCircle(240, 160, 120, TFT_BLACK);
+    tft.fillCircle(240, 160, 100, TFT_WHITE);
     vTaskDelay(2000 / portTICK_PERIOD_MS);
     SerialPrintfln("setup: ....  seek for WiFi networks");
     if(!connectToWiFi()){

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1510,13 +1510,18 @@ void setup() {
     if(TFT_CONTROLLER > 6) SerialPrintfln(ANSI_ESC_RED "The value in TFT_CONTROLLER is invalid");
 
     drawImage("/common/MiniWebRadioV3.jpg", 0, 0); // Welcomescreen
-    tft.drawLine(0, 0, 400, 300, TFT_GREEN); // clear line
-    vTaskDelay(2000 / portTICK_PERIOD_MS);
+
     updateSettings();
     if(_brightness < 5) _brightness = 5;
     if(_volumeSteps < 21) _volumeSteps = 21;
     setTFTbrightness(_brightness);
-
+    tft.drawTriangle(0, 0, 479, 0, 479, 319, TFT_RED);
+    tft.fillTriangle(0, 0, 479, 0, 479, 319, TFT_RED);
+    tft.drawRect(0, 0, 480, 320, TFT_WHITE);
+    tft.drawRoundRect(0, 0, 480, 320, 30, TFT_YELLOW);
+    tft.fillRoundRect(0, 0, 480, 320, 60, TFT_GREEN);
+    tft.drawCircle(240, 160, 20, TFT_BLACK);
+    vTaskDelay(2000 / portTICK_PERIOD_MS);
     SerialPrintfln("setup: ....  seek for WiFi networks");
     if(!connectToWiFi()){
         openAccessPoint();


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/7c6904fe-6261-4e7a-8b38-3cdd7413cc1f)

click on info cover creates a "hardcopy.bmp" on SD and show it in the webpage
is now working for all TFT controller

intreoduce a framebuffer (double buffering), that allows the alpha channel in png for transparent images